### PR TITLE
feat: use bind mount for runcitadel/core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,9 +114,6 @@ RUN apt-get update &&                                                          \
             python3-yaml                                                       \
             python3-requests &&                                                \
                                                                                \
-    git clone https://github.com/runcitadel/core.git /home/citadel/citadel &&  \
-    chown -R 1000:1000 /home/citadel/citadel &&                                \
-                                                                               \
     # Housekeeping
     apt-get clean -y &&                                                        \
     rm -rf                                                                     \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export PATH="$PATH:$HOME/.citadel/bin"
 
 If you want to have it permanently, also add the line to the correct profile file (~/.bash_profile, ~/.zshrc, ~/.profile, or ~/.bashrc).
 
-### Install Dependencies
+### Install Dependencies (optional)
 
 Install the required dependencies if you haven't already
 
@@ -40,6 +40,12 @@ citadel install
 ```
 
 ## Usage
+
+Initialize your environment 
+
+```
+citadel init
+```
 
 Start Citadel and login in with the default credentials (user: _citadel_, password: _freedom_)
 
@@ -59,7 +65,7 @@ This CLI also serves as an easy way to bootstrap a development environment with 
 For linking @runcitadel packages use `yarn link -r ../<package>` & `yarn unlink ../<package>` as needed from the appropriate directory.
 
 ```
-citadel dev <directory>
+citadel init --development
 ```
 
 ## Troubleshoot

--- a/citadel
+++ b/citadel
@@ -447,9 +447,12 @@ if [[ "$command" = "destroy" ]]; then
   read -p "Are you sure? [y/N] "
   echo
   if [[ $REPLY =~ [Yy]$ ]]; then
-    echo "Shutting down Citadel..."
-    # Shutdown Citadel safely
-    run_in_container "scripts/stop" $target_container
+    if $(is_container_running $target_container); then
+      echo "Shutting down Citadel..."
+      # Shutdown Citadel safely
+      run_in_container "scripts/stop" $target_container
+    fi
+
     echo "Destroying container..."
     docker rm -f $target_container &>/dev/null
     echo "Citadel container destroyed."

--- a/citadel
+++ b/citadel
@@ -454,38 +454,7 @@ if [[ "$command" = "destroy" ]]; then
   exit
 fi
 
-# List container services
-# TODO: multiple
-if [[ "$command" = "containers" ]]; then
-  check_dependencies
-  check_container_name
-
-  run_in_container "docker compose config --services"
-  exit
-fi
-
-# Rebuild a container service
-# TODO: multiple
-if [[ "$command" = "rebuild" ]]; then
-  check_dependencies
-  check_container_name
-
-  if [ -z ${2+x} ]; then
-    echo "A second argument is required!"
-    exit 1
-  fi
-
-  container="$2"
-  run_in_container "                    \
-       docker compose build $container  \
-    && docker compose stop $container   \
-    && docker compose rm -f $container  \
-    && docker compose up -d $container"
-  exit
-fi
-
 # Backup the container
-# TODO: multiple
 if [[ "$command" = "backup" ]]; then
   check_dependencies
   check_container_name
@@ -550,23 +519,6 @@ if [[ "$command" = "restore" ]]; then
   else
     echo "Cancelled."
   fi
-  exit
-fi
-
-# Rebuild a container service
-# TODO: multiple
-if [[ "$command" = "app" ]]; then
-  check_dependencies
-  check_container_name
-
-  if [ -z ${2+x} ]; then
-    echo "A second argument is required!"
-    exit 1
-  else
-    args="${@:2}"
-  fi
-
-  run_in_container "scripts/app ${args}"
   exit
 fi
 

--- a/citadel
+++ b/citadel
@@ -457,6 +457,7 @@ fi
 # Backup the container
 if [[ "$command" = "backup" ]]; then
   check_dependencies
+  check_environment
   check_container_name
 
   current_date=$(date '+%Y-%m-%d')
@@ -523,9 +524,9 @@ if [[ "$command" = "restore" ]]; then
 fi
 
 # Stream Citadel logs
-# TODO: multiple
 if [[ "$command" = "logs" ]]; then
   check_dependencies
+  check_environment
   check_container_name
 
   shift
@@ -541,13 +542,14 @@ if [[ "$command" = "logs" ]]; then
 fi
 
 # Run a command inside the container
-# TODO: multiple
 if [[ "$command" = "run" ]]; then
   check_dependencies
+  check_environment
   check_container_name
 
   if [ -z ${2+x} ]; then
-    echo "A second argument is required!"
+    echo "Specify the command you want to run."
+    echo "Usage: \`$CLI_NAME $command \"<command>\"\`."
     exit 1
   fi
 
@@ -601,6 +603,7 @@ fi
 # Fund the wallet
 if [[ "$command" = "fund" ]]; then
   check_dependencies
+  check_environment
   check_regtest_mode
   check_inner_container "lightning"
   check_inner_container "bitcoin"
@@ -646,6 +649,7 @@ fi
 # Generate a block continuously
 if [[ "$command" = "auto-mine" ]]; then
   check_dependencies
+  check_environment
   check_regtest_mode
   check_inner_container "bitcoin"
 

--- a/citadel
+++ b/citadel
@@ -400,6 +400,8 @@ if [[ "$command" = "stop" ]]; then
     echo "Shutting down Citadel \"$target_container\"..."
   fi
 
+  # Shutdown Citadel safely
+  run_in_container "scripts/stop" $target_container
   docker stop $target_container 2>&1 >/dev/null
   exit
 fi
@@ -433,18 +435,21 @@ if [[ "$command" = "destroy" ]]; then
     check_container_name
     target_container=$(get_container_name)
     check_container_exists $target_container
-    echo "WARNING: This will completely remove \"$target_container\" and its data."
+    echo "WARNING: This will remove \"$target_container\"."
     echo "If you just want to stop the container run \`$CLI_NAME stop\`."
   else
     target_container=$2
     check_container_exists $target_container
-    echo "WARNING: This will completely remove \"$target_container\" and its data."
+    echo "WARNING: This will remove \"$target_container\"."
     echo "If you just want to stop the container run \`$CLI_NAME stop $target_container\`."
   fi
 
   read -p "Are you sure? [y/N] "
   echo
   if [[ $REPLY =~ [Yy]$ ]]; then
+    echo "Shutting down Citadel..."
+    # Shutdown Citadel safely
+    run_in_container "scripts/stop" $target_container
     echo "Destroying container..."
     docker rm -f $target_container &>/dev/null
     echo "Citadel container destroyed."

--- a/citadel
+++ b/citadel
@@ -38,53 +38,68 @@ if [[ "$command" = "install" ]]; then
   exit
 fi
 
-# Initialize a development environment
-if [[ "$command" = "dev" ]]; then
+# Initialize a Citadel environment
+if [[ "$command" = "init" ]]; then
   shift
 
-  if [ -z ${1+x} ]; then
-    printf "Missing target directory.\n"
-    echo "Usage: \`$CLI_NAME dev <directory>\`"
-    exit 1
-  fi
+  POSITIONAL_ARGS=()
 
-  directory=$1
+  development=false
   ssh=false
 
-  # parse arguments
-  for arg in "$@"; do
-    case "$1" in
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+    --dev | --development)
+      development=true
+      shift
+      ;;
     --ssh)
       ssh=true
-      shift 1
+      shift
+      ;;
+    -* | --*)
+      echo "Unknown option $1"
+      exit 1
       ;;
     *)
-      shift 1
+      POSITIONAL_ARGS+=("$1")
+      shift
       ;;
     esac
   done
 
-  # create target directory
+  set -- "${POSITIONAL_ARGS[@]}"
+
+  directory=${POSITIONAL_ARGS:-"."}
+
+  # create directory if it doesn't exist
   mkdir -p $directory
 
   if [[ "$(ls -A $directory)" ]]; then
-    echo "Target directory must be empty!"
+    echo "Directory must be empty!"
+    echo "You can specify a target directory with \`$CLI_NAME init <directory>\`"
     exit 1
   fi
 
   printf "\nCloning container repositories..."
 
-  repos="
-    runcitadel/core
-    runcitadel/manager
-    runcitadel/middleware
-    runcitadel/dashboard
-    runcitadel/ui
-    runcitadel/sdk
-    runcitadel/fs
-    runcitadel/utils
-    runcitadel/node-lndconnect
-    runcitadel/bitcoin-rpc"
+  if $development; then
+    touch "$directory/.citadel-dev"
+    repos="
+      runcitadel/core
+      runcitadel/manager
+      runcitadel/middleware
+      runcitadel/dashboard
+      runcitadel/ui
+      runcitadel/sdk
+      runcitadel/fs
+      runcitadel/utils
+      runcitadel/node-lndconnect
+      runcitadel/bitcoin-rpc"
+  else
+    touch "$directory/.citadel"
+    repos="runcitadel/core"
+  fi
 
   for repo in $repos; do
     echo
@@ -101,17 +116,30 @@ if [[ "$command" = "dev" ]]; then
 
     git clone "$url" "$directory/$repo"
 
-    if [[ $repo == "core" ]]; then
+    if [[ $development == true ]] && [[ $repo == "runcitadel/core" ]]; then
       printf "\nCopying Docker Compose overrides..."
       cp "$(get_script_location)/docker-compose.override.yml" "$directory/$repo"
     fi
   done
 
-  touch "$directory/.citadel-dev"
+  # TODO: move this to a helper
+  on_success="\xE2\x9C\x94"
+  on_fail="\xE2\x9D\x8C"
+  green="\e[1;32m"
+  red="\e[1;31m"
+  nc="\e[0m"
 
-  printf "\nYour development environment is now setup.\n"
-  printf "You can boot your system container with:\n\n"
-  printf "cd $directory && $CLI_NAME boot\n"
+  checkmark="${green}${on_success}${nc}"
+
+  if $development; then
+    printf "\n $checkmark Citadel development environment initialized successfully.\n"
+    printf "\nYou can boot the system container with:\n"
+  else
+    printf "\n $checkmark Citadel environment initialized successfully.\n"
+    printf "\nYou can boot the system container with:\n"
+  fi
+
+  printf "\`cd $directory && $CLI_NAME boot\`\n"
   exit
 fi
 
@@ -162,7 +190,8 @@ if [[ "$command" = "boot" ]]; then
     # save name to environment file
     echo $name >$PWD/.citadel-dev
 
-    docker run --detach --publish-all \
+    docker run \
+      --detach --publish-all \
       --runtime sysbox-runc \
       --env NETWORK=$network \
       --name $name \
@@ -183,7 +212,17 @@ if [[ "$command" = "boot" ]]; then
     }
   else
     echo "Booting with Bitcoin network set to $network..."
-    docker run --runtime sysbox-runc --env NETWORK=$network --detach --publish-all --name $name --hostname $name $IMAGE_NAME &>/dev/null || {
+    # save name to environment file
+    echo $name >$PWD/.citadel
+
+    docker run \
+      --detach --publish-all \
+      --runtime sysbox-runc \
+      --env NETWORK=$network \
+      --name $name \
+      --hostname $name \
+      --mount type=bind,source="$(pwd)/core",target=/home/citadel/citadel \
+      $IMAGE_NAME &>/dev/null || {
       echo "Container with name \"$name\" exists already. Either remove (or rename) it or create a new one by passing a different name with \`$CLI_NAME boot --name <name>\`."
       exit 1
     }
@@ -310,7 +349,7 @@ if [[ "$command" = "start" ]]; then
   check_container_exists $target_container
 
   if [ "$(docker container inspect -f '{{.State.Running}}' $target_container)" == "true" ]; then
-    echo "Citadel is already running."
+    echo "Citadel \"$target_container\" is already running."
     exit 1
   else
     if $with_target; then
@@ -358,7 +397,7 @@ if [[ "$command" = "stop" ]]; then
   else
     target_container=$2
     check_container_running $target_container
-    echo "Shutting down Citadel named \"$target_container\"..."
+    echo "Shutting down Citadel \"$target_container\"..."
   fi
 
   docker stop $target_container 2>&1 >/dev/null
@@ -610,8 +649,7 @@ fi
 # Fund the wallet
 if [[ "$command" = "fund" ]]; then
   check_dependencies
-  check_dev_environment
-  check_node_network
+  check_regtest_mode
   check_inner_container "lightning"
   check_inner_container "bitcoin"
 
@@ -656,8 +694,7 @@ fi
 # Generate a block continuously
 if [[ "$command" = "auto-mine" ]]; then
   check_dependencies
-  check_dev_environment
-  check_node_network
+  check_regtest_mode
   check_inner_container "bitcoin"
 
   # default to 5 seconds

--- a/citadel
+++ b/citadel
@@ -116,8 +116,8 @@ if [[ "$command" = "init" ]]; then
 
     git clone "$url" "$directory/$repo"
 
-    if [[ $development == true ]] && [[ $repo == "runcitadel/core" ]]; then
-      printf "\nCopying Docker Compose overrides..."
+    if [[ $development == true ]] && [[ $repo == "core" ]]; then
+      printf "\nCopying docker-compose.override.yml...\n"
       cp "$(get_script_location)/docker-compose.override.yml" "$directory/$repo"
     fi
   done

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -182,7 +182,7 @@ get_script_location() {
 
 # Check if required dependencies are installed
 check_dependencies() {
-  for cmd in "git" "docker" "sysbox"; do
+  for cmd in "git" "docker" "sysbox-runc"; do
     if ! command -v $cmd >/dev/null 2>&1; then
       echo "This script requires Git, Docker and Sysbox to be installed."
       echo

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -244,6 +244,14 @@ is_container_running() {
   fi
 }
 
+is_citadel_environment() {
+  if [ -f "$PWD/.citadel" ] || [ -f "$PWD/.citadel-dev" ]; then
+    echo true
+  else
+    echo false
+  fi
+}
+
 is_dev_environment() {
   if [ -f "$PWD/.citadel-dev" ]; then
     echo true
@@ -292,7 +300,17 @@ get_node_network() {
   echo $(trim $network)
 }
 
-# Check that command was called from a dev environment
+# Check that command was run from a Citadel environment
+check_environment() {
+  is_citadel_environment=$(is_citadel_environment)
+
+  if ! $is_citadel_environment; then
+    echo "This command can only be run from a Citadel environment."
+    exit 1
+  fi
+}
+
+# Check that command was run from a dev environment
 check_dev_environment() {
   is_dev_env=$(is_dev_environment)
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -26,9 +26,6 @@ Commands:
     restore <path>                     Restore a backup
     destroy                            Destroy a container
     run <command>                      Run a command inside the container
-    containers                         List container services
-    rebuild <container>                Rebuild a container service
-    app <command> [options]            Manages apps installations
     fund <amount>                      Fund the onchain wallet (regtest mode only)
     auto-mine <seconds>                Generate a block continuously (regtest mode only)
     logs                               Stream Citadel logs

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -14,7 +14,7 @@ Flags:
 
 Commands:
     install                            Builds the image and installs Docker + Sysbox
-    dev [options]                      Initialize a development environment
+    init [options]                     Initialize a Citadel environment
     boot [options]                     Run a new container
     start                              Start the container
     stop                               Stop the container
@@ -219,42 +219,21 @@ check_container_running() {
 # Check if container name is unambiguous
 check_container_name() {
   is_dev_env=$(is_dev_environment)
-  is_multiple=$(check_multiple)
 
   if $is_dev_env; then
     if [ -s "$PWD/.citadel-dev" ]; then
       return
     else
-      echo "No container found for this environment. Try booting with \`citadel boot\`."
+      echo "No container found for the current directory. Change to a Citadel environment or specify a target."
       exit 1
     fi
-  fi
-
-  return
-
-  # TODO: enable multiple
-  #   if ! $is_multiple; then
-  #     docker ps --all --filter "ancestor=$IMAGE_NAME" --format '{{.Names}}' || {
-  #       exit 1
-  #     }
-  #   else
-  #     cat >&2 <<EOF
-  # More than one instance of Citadel found on your system.
-  # Either run this command again from a Citadel environment
-  # or specify a target container. Run \`citadel list\`
-  # to get an ID or name of a target container.
-  # EOF
-  #     exit 1
-  #   fi
-}
-
-check_multiple() {
-  containers=($(docker ps --all --filter "ancestor=$IMAGE_NAME" --format '{{.Names}}'))
-
-  if [[ ${#containers[@]} -gt 1 ]]; then
-    echo true
   else
-    echo false
+    if [ -s "$PWD/.citadel" ]; then
+      return
+    else
+      echo "No container found for the current directory. Change to a Citadel environment or specify a target."
+      exit 1
+    fi
   fi
 }
 
@@ -278,13 +257,11 @@ is_dev_environment() {
 
 get_container_name() {
   is_dev_env=$(is_dev_environment)
-  # is_multiple=$(check_multiple)
 
   if $is_dev_env; then
     cat "$PWD/.citadel-dev"
   else
-    # TODO:
-    echo 'citadel'
+    cat "$PWD/.citadel"
   fi
 }
 
@@ -329,7 +306,7 @@ check_dev_environment() {
 }
 
 # Check that network is regtest
-check_node_network() {
+check_regtest_mode() {
   network=$(get_node_network)
 
   if [[ ! "$network" == *"regtest"* ]]; then

--- a/scripts/install-docker.sh
+++ b/scripts/install-docker.sh
@@ -14,3 +14,8 @@ fi
 
 # install
 curl -fsSL https://get.docker.com | sudo sh
+
+# Create docker group, add current user to it, and reload the group
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker


### PR DESCRIPTION
- use a bind mount for core to persist data
- removes some commands that will be covered by Citadel CLI
- fixes docker install script by creating the docker group and adding the user
- update docs to reflect these changes

This is similiar to like it was before with the Vagrant VM. I wanted to do without a "environment" directory at first since Docker doesn't need it but it's better to have the data on the host and bind mount it into the container so you can destroy the container safely without losing anything. I still need to test this though.